### PR TITLE
Update to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     default: '{}'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
Now that Node.js 12 actions are deprecated, action.yml indicates a Node.js 16 runtime.